### PR TITLE
feat(toc): implement toc sidebar

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -5,14 +5,14 @@
   --page-gutter: 24px;
   --header-height: 48px;
   --footer-height: 48px;
-  --sidebar-top: 70px;
+  --sidebar-top: 72px;
 
   --content-width: 40rem;
   --content-height: calc(100vh - (var(--page-top) * 2) - var(--footer-height));
 
-  @media (min-width: 640px) {
-    --page-top: 192px;
-    --sidebar-top: 300px;
+  @media (min-width: 1080px) {
+    --page-top: 128px;
+    --sidebar-top: 144px;
     --page-gutter: 48px;
   }
 }
@@ -119,6 +119,12 @@ pre > code {
 /* ################################# */
 /* #       Table of contents       # */
 /* ################################# */
+@media screen and (min-width: 1080px) {
+  #toc {
+    @apply fixed top-0 left-0 z-40 w-1/4 px-page-gutter py-sidebar-top;
+  }
+}
+
 #toc-list ol {
   @apply pl-3 m-1 border-l-2 text-sm text-muted;
   counter-reset: tocitem;

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,17 +4,7 @@
   {{- partial "date" .Date -}}{{ if ne .Date .Lastmod }}<nobr class="text-sm text-muted">&#8674&nbsp;</nobr>{{- partial "date" .Lastmod -}}{{ end }}
 
   {{- partial "tag" . -}}
-  <!-- Table of contents -->
-  {{ if default true (default .Site.Params.toc .Params.toc) }}
-    {{ if gt (.TableOfContents | countwords)
-      0
-    }}
-      <details>
-        <summary>Table of contents</summary>
-        <div id="toc-list">{{ .TableOfContents }}</div>
-      </details>
-    {{ end }}
-  {{ end }}
+  {{- partial "toc.html" . -}}
   <!-- Content -->
   {{- partial "custom/content-before.html" . -}}
   <div class="content">{{ .Content | emojify }}</div>

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,0 +1,13 @@
+<!-- Table of contents -->
+<div id="toc">
+  {{ if default true (default .Site.Params.toc .Params.toc) }}
+    {{ if gt (.TableOfContents | countwords)
+      0
+    }}
+      <details>
+        <summary>Table of contents</summary>
+        <div id="toc-list">{{ .TableOfContents }}</div>
+      </details>
+    {{ end }}
+  {{ end }}
+</div>


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Implement Table of content (TOC) as floating sidebar in large screen device. In the smaller devices, just use the original TOC.

## Preview

![image](https://github.com/ntk148v/hugo-toigian/assets/10803803/ebb3c5e7-ccbe-4a31-a1d6-1358c258ed5f)

![image](https://github.com/ntk148v/hugo-toigian/assets/10803803/53e6acc9-9df8-4fc5-8160-9f0c53789881)



## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)
