### PR TITLE
Remove async on script tag.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -124,7 +124,6 @@
 
   <!-- mermaid -->
   <script
-    async
     defer
     src="{{ $main_js.RelPermalink }}"
     integrity="{{- $main_js.Data.Integrity -}}"


### PR DESCRIPTION
Async script loading can cause DOMContentLoaded listener in main.js to be missed

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)
